### PR TITLE
fix: isolate Sonic and Monad gas estimation

### DIFF
--- a/src/tenderly-tooling/gas/evm.ts
+++ b/src/tenderly-tooling/gas/evm.ts
@@ -1,0 +1,60 @@
+import { ChainId, type TenderlySimulationResponse } from "@aave-dao/toolbox";
+import type { Client } from "viem";
+
+export const UNCAPPED_GAS_LIMIT_CHAINS: number[] = [
+  ChainId.mantle,
+  ChainId.megaeth,
+];
+
+export const fmtGas = (g: bigint) => g.toLocaleString("en-US");
+
+/**
+ * Resolves a network's max per-transaction gas limit — the cap a single tx may
+ * consume; a payload exceeding it can never be included on-chain.
+ *
+ * We assume 2^24 (16,777,216, Ethereum's EIP-7825 cap) is the LOWEST such cap of
+ * any supported network, so it is the default and this function always returns at
+ * least that value. Unconfigured chains therefore get the most conservative bound
+ * (most likely to flag), never an under-estimate.
+ */
+export function getMaxTxGasLimit(chainId: number): bigint {
+  switch (chainId) {
+    // Polygon PoS — Madhugiri hardfork (Gigagas Phase 3, Dec 2025); EIP-8123: "Arbitrum and Polygon both use 32,000,000".
+    case 137:
+    // Arbitrum One — ArbOS 51 ("Dia") MaxTxGasLimit, live 2026-01-08; configurable via the ArbOwner precompile but 32M is the shipping value. https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos51
+    case 42161:
+      return 32_000_000n;
+    // ZKsync Era — bootloader-enforced MAX_TX_GAS for computation; no traditional block.gasLimit. https://docs.zksync.io/zksync-protocol/era-vm/contracts/bootloader
+    case 324:
+      return 80_000_000n;
+    // MegaETH — protocol-level compute gas limit (block limit is 10B, this is far tighter). https://docs.megaeth.com/spec
+    case 4326:
+      return 200_000_000n;
+    // Default: 2^24 = 16,777,216 — Ethereum's EIP-7825 cap (https://eips.ethereum.org/EIPS/eip-7825).
+    // Gnosis (100, Fusaka EIP-7825) and Base (8453, Azul hardfork) are also exactly
+    // 2^24, and we assume this is the lowest cap across networks, so every other
+    // chain (known or not) safely falls back to it.
+    default:
+      return 16_777_216n;
+  }
+}
+
+export function prepareEvmGas({ client }: { client: Client }) {
+  const gasLimit = UNCAPPED_GAS_LIMIT_CHAINS.includes(client.chain!.id)
+    ? 0n
+    : 16_000_000n;
+  return {
+    gasLimit,
+    vnetOverrides: { gas_limit: Number(gasLimit) },
+    // Preserve wallet-side estimation for the default path.
+    transactionOverrides: {},
+    render(sim: TenderlySimulationResponse): string {
+      const gasUsed = BigInt((sim.transaction as any).gas_used ?? 0);
+      const maxTxGasLimit = getMaxTxGasLimit(client.chain!.id);
+      if (gasUsed > maxTxGasLimit) {
+        return `- :sos: gasUsed: ${fmtGas(gasUsed)} — **exceeds ${client.chain!.name}'s max transaction gas limit of ${fmtGas(maxTxGasLimit)}; this payload cannot be executed in a single transaction**\n`;
+      }
+      return `- gasUsed: ${fmtGas(gasUsed)} (max tx gas limit: ${fmtGas(maxTxGasLimit)})\n`;
+    },
+  };
+}

--- a/src/tenderly-tooling/gas/index.spec.ts
+++ b/src/tenderly-tooling/gas/index.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { createClient, custom } from "viem";
+import type { TenderlySimulationResponse } from "@aave-dao/toolbox";
+import { monad, sonic } from "viem/chains";
+import { prepareGas } from "./index";
+
+const rules = {
+  Dag: { MaxParents: 12, MaxFreeParents: 6, MaxExtraData: 128 },
+  Economy: {
+    Gas: {
+      MaxEventGas: 30_000_000,
+      EventGas: 28_000,
+      ParentGas: 2_400,
+      ExtraDataGas: 25,
+    },
+  },
+};
+const simulation = (gasUsed: number) =>
+  ({
+    transaction: { gas_used: gasUsed },
+    simulation: { status: true },
+  }) as unknown as TenderlySimulationResponse;
+
+describe.each([
+  {
+    name: "Monad",
+    chain: monad,
+    cap: 30_000_000n,
+    inflated: 750_000_000,
+  },
+  {
+    name: "Sonic",
+    chain: sonic,
+    cap: 29_954_400n,
+    inflated: 560_160_288,
+  },
+])("$name gas", ({ chain, cap, inflated }) => {
+  const options = {
+    client: createClient({
+      chain,
+      transport: custom({ request: async () => rules }),
+    }),
+    blockNumber: 100,
+  };
+
+  it("ignores inflated charged gas and estimates against the transaction cap", async () => {
+    const estimate = vi.fn().mockResolvedValue(600_001n);
+    const gas = await prepareGas({ ...options, estimate });
+    expect(estimate).toHaveBeenCalledWith(cap);
+    expect(gas.gasLimit).toBe(720_002n);
+    const report = gas.render(simulation(inflated));
+    expect(report).toContain(
+      "estimated gas: 600,001 (prepared VNet eth_estimateGas)",
+    );
+    expect(report).not.toContain(inflated.toLocaleString("en-US"));
+  });
+
+  it("caps the buffer without declaring an otherwise fitting estimate impossible", async () => {
+    const gas = await prepareGas({
+      ...options,
+      estimate: async () => cap - 1n,
+    });
+    expect(gas.gasLimit).toBe(cap);
+    expect(gas.render(simulation(inflated))).toContain(
+      "20% safety margin exceeds",
+    );
+    expect(gas.render(simulation(inflated))).not.toContain(
+      "cannot be executed",
+    );
+  });
+});

--- a/src/tenderly-tooling/gas/index.ts
+++ b/src/tenderly-tooling/gas/index.ts
@@ -1,0 +1,19 @@
+import type { Client, Hex } from "viem";
+import { prepareEvmGas } from "./evm";
+import { prepareMonadGas } from "./monad";
+import { prepareSonicGas } from "./sonic";
+
+export async function prepareGas(params: {
+  client: Client;
+  blockNumber: number | Hex | "latest";
+  estimate?: (gasLimit: bigint) => Promise<bigint>;
+}) {
+  switch (params.client.chain!.id) {
+    case 146:
+      return prepareSonicGas(params);
+    case 143:
+      return prepareMonadGas(params);
+    default:
+      return prepareEvmGas(params);
+  }
+}

--- a/src/tenderly-tooling/gas/monad.ts
+++ b/src/tenderly-tooling/gas/monad.ts
@@ -1,0 +1,71 @@
+import type { TenderlySimulationResponse } from "@aave-dao/toolbox";
+import { fmtGas } from "./evm";
+
+// Monad charges the submitted limit, so transaction.gas_used is not an estimate.
+// https://docs.monad.xyz/developer-essentials/gas-pricing
+export async function prepareMonadGas({
+  estimate,
+}: {
+  estimate?: (gasLimit: bigint) => Promise<bigint>;
+}) {
+  const maxGas = 30_000_000n;
+  let estimatedGas: bigint | undefined;
+  try {
+    const value = await estimate?.(maxGas);
+    if (typeof value === "bigint" && value > 0n) estimatedGas = value;
+  } catch {
+    // Keep the prepared VNet; a failed estimator must not trigger stateless replay.
+  }
+  const bufferedGas = estimatedGas && (estimatedGas * 120n + 99n) / 100n;
+  const gasLimit = bufferedGas && bufferedGas < maxGas ? bufferedGas : maxGas;
+
+  return {
+    gasLimit,
+    vnetOverrides: { gas: Number(gasLimit), block_number: null },
+    transactionOverrides: { gas: gasLimit },
+    render(sim: TenderlySimulationResponse): string {
+      let report = `- requested simulation gas limit: ${fmtGas(gasLimit)} (Monad max tx gas limit: ${fmtGas(maxGas)})\n`;
+      if (estimatedGas !== undefined) {
+        report += `- estimated gas: ${fmtGas(estimatedGas)} (prepared VNet eth_estimateGas)\n`;
+        if (estimatedGas > maxGas) {
+          report +=
+            "- :warning: gas estimate exceeds Monad's transaction limit; execution within the cap is not established.\n";
+        } else if (bufferedGas! > maxGas) {
+          report +=
+            "- :warning: gas estimate fits, but the 20% safety margin exceeds the transaction limit.\n";
+        }
+      } else {
+        report +=
+          "- :warning: prepared VNet gas estimate unavailable; gas executability is not established.\n";
+      }
+
+      // Trace consumption is useful evidence, but not the minimum gas allowance
+      // (refunds and EIP-150 call forwarding can make those differ).
+      const info = sim.transaction.transaction_info as
+        | {
+            intrinsic_gas?: number;
+            call_trace?: { gas_used?: number };
+          }
+        | undefined;
+      const intrinsic = info?.intrinsic_gas;
+      const execution = info?.call_trace?.gas_used;
+      if (
+        sim.simulation.status &&
+        Number.isSafeInteger(intrinsic) &&
+        intrinsic! >= 0 &&
+        Number.isSafeInteger(execution) &&
+        execution! >= 0
+      ) {
+        report += `- trace gas: ${fmtGas(BigInt(intrinsic!) + BigInt(execution!))} (approximate consumption, not a gas-limit estimate)\n`;
+      }
+      if (!estimate) {
+        report +=
+          "- :warning: prepared VNet state was unavailable; this assessment is provisional.\n";
+      }
+      return (
+        report +
+        "- Monad charges the submitted gas limit; Tenderly's top-level gas_used is excluded from the execution estimate.\n"
+      );
+    },
+  };
+}

--- a/src/tenderly-tooling/gas/sonic.spec.ts
+++ b/src/tenderly-tooling/gas/sonic.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { createClient, custom } from "viem";
+import type { TenderlySimulationResponse } from "@aave-dao/toolbox";
+import { prepareSonicGas } from "./sonic";
+
+const rules = {
+  Dag: { MaxParents: 12, MaxFreeParents: 6, MaxExtraData: 128 },
+  Economy: {
+    Gas: {
+      MaxEventGas: 30_000_000,
+      EventGas: 28_000,
+      ParentGas: 2_400,
+      ExtraDataGas: 25,
+    },
+  },
+};
+const simulation = {
+  transaction: {},
+  simulation: { status: true },
+} as TenderlySimulationResponse;
+
+describe("Sonic rules", () => {
+  it("reads rules at the fork block, including historical caps", async () => {
+    const historicalRequest = vi.fn().mockResolvedValue({
+      ...rules,
+      Economy: { Gas: { ...rules.Economy.Gas, MaxEventGas: 100_000_000 } },
+    });
+    const gas = await prepareSonicGas({
+      client: createClient({
+        transport: custom({ request: historicalRequest }),
+      }),
+      blockNumber: "0x1234",
+    });
+    expect(historicalRequest).toHaveBeenCalledWith({
+      method: "eth_getRules",
+      params: ["0x1234"],
+    });
+    expect(gas.gasLimit).toBe(99_954_400n);
+    expect(gas.render(simulation)).toContain("eth_getRules at 0x1234");
+  });
+
+  it("still estimates if the provider does not support eth_getRules", async () => {
+    const estimate = vi.fn().mockResolvedValue(500_000n);
+    const gas = await prepareSonicGas({
+      client: createClient({
+        transport: custom(
+          {
+            request: async () => {
+              throw new Error("unsupported");
+            },
+          },
+          { retryCount: 0 },
+        ),
+      }),
+      blockNumber: "latest",
+      estimate,
+    });
+    expect(estimate).toHaveBeenCalledWith(29_954_400n);
+    expect(gas.render(simulation)).toContain("estimated gas: 500,000");
+    expect(gas.render(simulation)).toContain("active rules unverified");
+  });
+});

--- a/src/tenderly-tooling/gas/sonic.ts
+++ b/src/tenderly-tooling/gas/sonic.ts
@@ -1,0 +1,133 @@
+import type { TenderlySimulationResponse } from "@aave-dao/toolbox";
+import { type Client, type EIP1193RequestFn, type Hex, toHex } from "viem";
+import { fmtGas } from "./evm";
+
+type SonicRules = {
+  Dag: { MaxParents: number; MaxFreeParents: number; MaxExtraData: number };
+  Economy: {
+    Gas: {
+      MaxEventGas: number;
+      EventGas: number;
+      ParentGas: number;
+      ExtraDataGas: number;
+    };
+  };
+};
+
+// https://docs.soniclabs.com/sonic/build-on-sonic/network-parameters
+// CurrentMaxGasLimit: https://github.com/0xsoniclabs/sonic/blob/51d8de55e8e3752919ef41b26dccf28e5f69d9d8/gossip/evm_state_reader.go#L86-L96
+export async function prepareSonicGas({
+  client,
+  blockNumber,
+  estimate,
+}: {
+  client: Client;
+  blockNumber: number | Hex | "latest";
+  estimate?: (gasLimit: bigint) => Promise<bigint>;
+}) {
+  let maxGas = 29_954_400n;
+  let source = ":warning: documented fallback; active rules unverified";
+  try {
+    const request = client.request as EIP1193RequestFn<
+      [
+        {
+          Method: "eth_getRules";
+          Parameters: [Hex | "latest"];
+          ReturnType: SonicRules;
+        },
+      ]
+    >;
+    const block =
+      typeof blockNumber === "number" ? toHex(blockNumber) : blockNumber;
+    const {
+      Dag: dag,
+      Economy: { Gas: gas },
+    } = await request({
+      method: "eth_getRules",
+      params: [block],
+    });
+    const values = [
+      dag.MaxParents,
+      dag.MaxFreeParents,
+      dag.MaxExtraData,
+      gas.MaxEventGas,
+      gas.EventGas,
+      gas.ParentGas,
+      gas.ExtraDataGas,
+    ];
+    if (
+      values.some((value) => !Number.isSafeInteger(value) || value < 0) ||
+      dag.MaxParents < dag.MaxFreeParents
+    ) {
+      throw new Error("Invalid Sonic gas rules");
+    }
+    const limit =
+      BigInt(gas.MaxEventGas) -
+      BigInt(gas.EventGas) -
+      BigInt(dag.MaxParents - dag.MaxFreeParents) * BigInt(gas.ParentGas) -
+      BigInt(dag.MaxExtraData) * BigInt(gas.ExtraDataGas);
+    if (limit <= 0n) throw new Error("Invalid Sonic transaction gas limit");
+    maxGas = limit;
+    source = `eth_getRules at ${block}`;
+  } catch {
+    // Some gateways do not expose Sonic's nonstandard RPC. Label the fallback.
+  }
+
+  let estimatedGas: bigint | undefined;
+  try {
+    const value = await estimate?.(maxGas);
+    if (typeof value === "bigint" && value > 0n) estimatedGas = value;
+  } catch {
+    // Preserve the prepared VNet and simulate at the cap when estimation fails.
+  }
+  // https://docs.soniclabs.com/sonic/build-on-sonic/gas-pricing
+  const bufferedGas = estimatedGas && (estimatedGas * 120n + 99n) / 100n;
+  const gasLimit = bufferedGas && bufferedGas < maxGas ? bufferedGas : maxGas;
+
+  return {
+    gasLimit,
+    vnetOverrides: { gas: Number(gasLimit), block_number: null },
+    transactionOverrides: { gas: gasLimit },
+    render(sim: TenderlySimulationResponse): string {
+      let report = `- requested simulation gas limit: ${fmtGas(gasLimit)} (Sonic max tx gas limit: ${fmtGas(maxGas)}; ${source})\n`;
+      if (estimatedGas !== undefined) {
+        report += `- estimated gas: ${fmtGas(estimatedGas)} (prepared VNet eth_estimateGas)\n`;
+        if (estimatedGas > maxGas) {
+          report +=
+            "- :warning: gas estimate exceeds Sonic's transaction limit; execution within the cap is not established.\n";
+        } else if (bufferedGas! > maxGas) {
+          report +=
+            "- :warning: gas estimate fits, but the 20% safety margin exceeds the transaction limit.\n";
+        }
+      } else {
+        report +=
+          "- :warning: prepared VNet gas estimate unavailable; gas executability is not established.\n";
+      }
+      const info = sim.transaction.transaction_info as
+        | {
+            intrinsic_gas?: number;
+            call_trace?: { gas_used?: number };
+          }
+        | undefined;
+      const intrinsic = info?.intrinsic_gas;
+      const execution = info?.call_trace?.gas_used;
+      if (
+        sim.simulation.status &&
+        Number.isSafeInteger(intrinsic) &&
+        intrinsic! >= 0 &&
+        Number.isSafeInteger(execution) &&
+        execution! >= 0
+      ) {
+        report += `- trace gas: ${fmtGas(BigInt(intrinsic!) + BigInt(execution!))} (approximate consumption, not a gas-limit estimate)\n`;
+      }
+      if (!estimate) {
+        report +=
+          "- :warning: prepared VNet state was unavailable; this assessment is provisional.\n";
+      }
+      return (
+        report +
+        "- Tenderly's top-level gas_used is excluded: Sonic gas accounting can include unused-gas charges.\n"
+      );
+    },
+  };
+}

--- a/src/tenderly-tooling/tenderly-report.ts
+++ b/src/tenderly-tooling/tenderly-report.ts
@@ -24,11 +24,13 @@ import {
   Payload,
 } from "@aave-dao/toolbox";
 
-import { getMdContractName, getMaxTxGasLimit, fmtGas } from "./utils";
+import { getMdContractName } from "./utils";
+import { prepareEvmGas } from "./gas/evm";
 
 type RenderTenderlyReportParams = {
   client: Client;
   sim: TenderlySimulationResponse;
+  gasReport?: string;
   payloadId: number;
   payload: Payload;
   onchainLogs: {
@@ -49,6 +51,7 @@ type RenderTenderlyReportParams = {
 export async function renderTenderlyReport({
   client,
   sim,
+  gasReport,
   payloadId,
   payload,
   onchainLogs: { createdLog, queuedLog, executedLog },
@@ -105,14 +108,7 @@ ${payload.actions
     }
   }
 
-  // gas used by the executePayload tx, flagged against the network's max tx gas limit
-  const gasUsed = BigInt((sim.transaction as any).gas_used ?? 0);
-  const maxTxGasLimit = getMaxTxGasLimit(client.chain!.id);
-  if (gasUsed > maxTxGasLimit) {
-    report += `- :sos: gasUsed: ${fmtGas(gasUsed)} — **exceeds ${client.chain!.name}'s max transaction gas limit of ${fmtGas(maxTxGasLimit)}; this payload cannot be executed in a single transaction**\n`;
-  } else {
-    report += `- gasUsed: ${fmtGas(gasUsed)} (max tx gas limit: ${fmtGas(maxTxGasLimit)})\n`;
-  }
+  report += gasReport ?? prepareEvmGas({ client }).render(sim);
 
   report += "\n";
 

--- a/src/tenderly-tooling/utils.ts
+++ b/src/tenderly-tooling/utils.ts
@@ -16,42 +16,6 @@ import {
 
 export type AssetInfo = { symbol: string; decimals: number };
 
-export const fmtGas = (g: bigint) => g.toLocaleString("en-US");
-
-/**
- * Resolves a network's max per-transaction gas limit — the cap a single tx may
- * consume; a payload exceeding it can never be included on-chain.
- *
- * We assume 2^24 (16,777,216, Ethereum's EIP-7825 cap) is the LOWEST such cap of
- * any supported network, so it is the default and this function always returns at
- * least that value. Unconfigured chains therefore get the most conservative bound
- * (most likely to flag), never an under-estimate.
- */
-export function getMaxTxGasLimit(chainId: number): bigint {
-  switch (chainId) {
-    // Polygon PoS — Madhugiri hardfork (Gigagas Phase 3, Dec 2025); EIP-8123: "Arbitrum and Polygon both use 32,000,000".
-    case 137:
-    // Arbitrum One — ArbOS 51 ("Dia") MaxTxGasLimit, live 2026-01-08; configurable via the ArbOwner precompile but 32M is the shipping value. https://docs.arbitrum.io/run-arbitrum-node/arbos-releases/arbos51
-    case 42161:
-      return 32_000_000n;
-    // ZKsync Era — bootloader-enforced MAX_TX_GAS for computation; no traditional block.gasLimit. https://docs.zksync.io/zksync-protocol/era-vm/contracts/bootloader
-    case 324:
-      return 80_000_000n;
-    // MegaETH — protocol-level compute gas limit (block limit is 10B, this is far tighter). https://docs.megaeth.com/spec
-    case 4326:
-      return 200_000_000n;
-    // Monad - 30M transaction gas limit. 200M block gas limit, https://docs.monad.xyz/developer-essentials/gas-pricing
-    case 143:
-      return 30_000_000n;
-    // Default: 2^24 = 16,777,216 — Ethereum's EIP-7825 cap (https://eips.ethereum.org/EIPS/eip-7825).
-    // Gnosis (100, Fusaka EIP-7825) and Base (8453, Azul hardfork) are also exactly
-    // 2^24, and we assume this is the lowest cap across networks, so every other
-    // chain (known or not) safely falls back to it.
-    default:
-      return 16_777_216n;
-  }
-}
-
 const assetsCache: Record<number, Record<Hex, AssetInfo>> = {};
 
 /**

--- a/src/tenderly.spec.ts
+++ b/src/tenderly.spec.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getClient,
+  tenderly_createVnet,
+  tenderly_sim,
+} from "@aave-dao/toolbox";
+import { renderTenderlyReport } from "./tenderly-tooling/tenderly-report";
+import { makePayloadExecutableOnTestClient } from "./tenderly-tooling/payloads-controller";
+import { simulateOnTenderly } from "./tenderly";
+
+vi.mock("@aave-dao/toolbox", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@aave-dao/toolbox")>()),
+  getClient: vi.fn(),
+  tenderly_createVnet: vi.fn(),
+  tenderly_sim: vi.fn(),
+}));
+vi.mock("./tenderly-tooling/tenderly-report", () => ({
+  renderTenderlyReport: vi
+    .fn()
+    .mockResolvedValue({ report: "report", eventCache: [] }),
+}));
+vi.mock("./tenderly-tooling/payloads-controller", () => ({
+  makePayloadExecutableOnTestClient: vi.fn(),
+  getPayloadStorageOverrides: vi.fn().mockResolvedValue([]),
+}));
+
+const result = {
+  simulation: { status: true },
+  transaction: {
+    gas_used: 750_000_000,
+  },
+};
+let order: string[];
+let vnet: any;
+const params = (chainId: number) =>
+  ({
+    chainId,
+    payloadId: 2,
+    payloadsController: "0x0000000000000000000000000000000000000001" as const,
+    executeBefore: [1],
+    cache: {
+      logs: {
+        createdLog: { transactionHash: "0x01", blockNumber: 1, timestamp: 1 },
+      },
+      payload: {} as Parameters<
+        typeof simulateOnTenderly
+      >[0]["cache"]["payload"],
+    },
+  }) as Parameters<typeof simulateOnTenderly>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order = [];
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  const rulesRequest = vi.fn().mockResolvedValue({
+    Dag: { MaxParents: 12, MaxFreeParents: 6, MaxExtraData: 128 },
+    Economy: {
+      Gas: {
+        MaxEventGas: 30_000_000,
+        EventGas: 28_000,
+        ParentGas: 2_400,
+        ExtraDataGas: 25,
+      },
+    },
+  });
+  vi.mocked(getClient).mockImplementation(
+    (chainId) =>
+      ({
+        request: rulesRequest,
+        chain: { id: chainId, name: `Chain ${chainId}` },
+      }) as any,
+  );
+  vi.mocked(makePayloadExecutableOnTestClient).mockImplementation(
+    async (_client, _controller, id) => {
+      order.push(`prepare ${id}`);
+    },
+  );
+  vnet = {
+    vnet: { fork_config: { block_number: "0x1234" } },
+    testClient: {
+      estimateGas: vi.fn(async () => {
+        order.push("estimate");
+        return 600_000n;
+      }),
+    },
+    walletClient: {
+      writeContract: vi.fn(async ({ args }) => {
+        order.push(`execute ${args[0]}`);
+      }),
+    },
+    simulate: vi.fn(async () => {
+      order.push("simulate");
+      return result;
+    }),
+    delete: vi.fn(),
+  };
+  vi.mocked(tenderly_createVnet).mockResolvedValue(vnet);
+  vi.mocked(tenderly_sim).mockResolvedValue(result as any);
+});
+
+describe.each([143, 146])("gas integration on chain %i", (chainId) => {
+  it("estimates after prerequisites and applies the same bounded gas to simulation and execution", async () => {
+    await simulateOnTenderly(params(chainId));
+    expect(order).toEqual([
+      "prepare 1",
+      "execute 1",
+      "prepare 2",
+      "estimate",
+      "simulate",
+      "execute 2",
+    ]);
+    const body = vnet.simulate.mock.calls[0][0];
+    expect(vnet.testClient.estimateGas).toHaveBeenCalledWith({
+      account: body.from,
+      to: body.to,
+      data: body.input,
+      gas: chainId === 143 ? 30_000_000n : 29_954_400n,
+      gasPrice: 0n,
+      value: 0n,
+    });
+    expect(body.gas).toBe(720_000);
+    expect(body.block_number).toBeNull(); // Use prepared VNet head, not the base-chain block.
+    expect(vnet.walletClient.writeContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ gas: 720_000n, args: [2] }),
+    );
+    expect(renderTenderlyReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gasReport: expect.stringContaining("estimated gas: 600,000"),
+      }),
+    );
+    expect(tenderly_sim).not.toHaveBeenCalled();
+  });
+
+  it("retains the prepared VNet on estimator failure", async () => {
+    vnet.testClient.estimateGas.mockRejectedValue(new Error("estimate failed"));
+    await simulateOnTenderly(params(chainId));
+    expect(tenderly_sim).not.toHaveBeenCalled();
+    expect(vnet.simulate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gas: chainId === 143 ? 30_000_000 : 29_954_400,
+      }),
+    );
+    expect(renderTenderlyReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gasReport: expect.stringContaining("estimate unavailable"),
+      }),
+    );
+  });
+});

--- a/src/tenderly.ts
+++ b/src/tenderly.ts
@@ -12,6 +12,7 @@ import { providerConfig } from "./common";
 import { eventDb } from "@aave-dao/aave-helpers-js";
 import { renderTenderlyReport } from "./tenderly-tooling/tenderly-report";
 import { getMdContractName } from "./tenderly-tooling/utils";
+import { prepareGas } from "./tenderly-tooling/gas";
 import {
   getPayloadStorageOverrides,
   makePayloadExecutableOnTestClient,
@@ -20,10 +21,6 @@ import {
 // https://docs.tenderly.co/supported-networks
 export const CHAIN_NOT_SUPPORTED_ON_TENDERLY: number[] = [ChainId.zkEVM];
 export const NO_V_NET: number[] = [ChainId.zksync];
-export const UNCAPPED_GAS_LIMIT_CHAINS: number[] = [
-  ChainId.mantle,
-  ChainId.megaeth,
-];
 
 type SimulateOnTenderlyParams = {
   chainId: number;
@@ -125,7 +122,6 @@ export async function simulateOnTenderly({
       }),
       block_number: blockNumber,
       transaction_index: 0,
-      gas_limit: UNCAPPED_GAS_LIMIT_CHAINS.includes(chainId) ? 0 : 16_000_000,
       gas_price: "0",
       value: "0",
       access_list: [],
@@ -133,6 +129,20 @@ export async function simulateOnTenderly({
       save: true,
       source: "dashboard",
     };
+    const gas = await prepareGas({
+      client: getClient(chainId, { providerConfig }),
+      blockNumber: vnet.vnet.fork_config.block_number,
+      estimate: (gasLimit) =>
+        vnet.testClient.estimateGas({
+          account: EOA,
+          to: payloadsController,
+          data: simPayload.input,
+          gas: gasLimit,
+          gasPrice: 0n,
+          value: 0n,
+        }),
+    });
+    Object.assign(simPayload, gas.vnetOverrides);
     const simResult = await vnet.simulate(simPayload);
     // after simulation execute payload
     await vnet.walletClient.writeContract({
@@ -142,12 +152,14 @@ export async function simulateOnTenderly({
       address: payloadsController,
       functionName: "executePayload",
       args: [payloadId],
+      ...gas.transactionOverrides,
     });
     const report = await renderTenderlyReport({
       payloadId: payloadId,
       payload: cache.payload,
       onchainLogs: cache.logs as any,
       sim: simResult,
+      gasReport: gas.render(simResult),
       client: vnet.testClient,
       config: {
         etherscanApiKey: process.env.ETHERSCAN_API_KEY!,
@@ -188,7 +200,6 @@ export async function simulateOnTenderly({
         args: [payloadId],
       }),
       block_number: blockNumber,
-      gas: UNCAPPED_GAS_LIMIT_CHAINS.includes(chainId) ? 0 : 16_000_000,
       state_objects: {
         [payloadsController]: {
           storage: overrides.reduce(
@@ -202,12 +213,18 @@ export async function simulateOnTenderly({
       },
       save: true,
     } as const;
+    const gas = await prepareGas({
+      client: getClient(chainId, { providerConfig }),
+      blockNumber: blockNumber < 0 ? "latest" : blockNumber,
+    });
+    Object.assign(simPayload, { gas: Number(gas.gasLimit) });
     const simResult = await tenderly_sim(tenderlyConfig, simPayload);
     const report = await renderTenderlyReport({
       payload: cache.payload,
       payloadId: payloadId,
       onchainLogs: cache.logs as any,
       sim: simResult,
+      gasReport: gas.render(simResult),
       client: getClient(chainId, {
         providerConfig,
       }),


### PR DESCRIPTION
Tenderly's top-level `gas_used` includes chain-specific charging on Sonic and Monad, causing payloads to be reported as exceeding transaction limits even when the reported value does not represent execution demand.

Move gas handling into `gas/evm.ts`, `gas/sonic.ts`, and `gas/monad.ts`, selected through `prepareGas` in `gas/index.ts`. The default EVM path preserves existing behavior.

For Sonic and Monad, estimate the exact transaction against the prepared VNet state, apply a 20% buffer bounded by the chain limit, and use that allowance for simulation and the follow-up transaction. Sonic resolves its limit from the fork block's rules with a labeled fallback; Monad retains its 30M limit. Reports separate the RPC estimate and approximate trace consumption from charged gas, and flag unavailable estimates without declaring the payload impossible.
